### PR TITLE
fix GPIO pin in docs for T-Camera Mini

### DIFF
--- a/docs/T_CameraMini.md
+++ b/docs/T_CameraMini.md
@@ -4,7 +4,7 @@
 
 |   Name    | T-Camera Mini |
 | :-------: | :-----------: |
-|  DVP Y9   |      19       |
+|  DVP Y9   |      39       |
 |  DVP Y8   |      36       |
 |  DVP Y7   |      38       |
 |  DVP Y6   |      37       |


### PR DESCRIPTION
GPIO pin in docs for T-Camera Mini is invalid
valid gpio for DVP Y9 is 39